### PR TITLE
create symbolic link to manpage

### DIFF
--- a/Debian/debian/links
+++ b/Debian/debian/links
@@ -1,0 +1,1 @@
+/usr/share/man/man1/notepadqq.1.gz   /usr/share/man/man1/notepadqq-bin.1.gz


### PR DESCRIPTION
This prevents a warning about /usr/bin/notepadqq-bin missing a manpage.
