### PR TITLE
make notepadqq depend on 'libqt5svg5 (>= 5.2.1)'

### DIFF
--- a/Debian/debian/control
+++ b/Debian/debian/control
@@ -18,6 +18,7 @@ Depends:
    notepadqq-common (>= ${source:Version}),
    notepadqq-common (<< ${source:Version}.1~),
    coreutils (>= 8.20),
+   libqt5svg5 (>= 5.2.1),
    ${shlibs:Depends},
    ${misc:Depends}
 Description: Notepad++-like editor for Linux


### PR DESCRIPTION
Otherwise the app's icon isn't displayed in the taskbar or the 'About' window.
`${shlibs:Depends}` or `${misc:Depends}` don't add it automatically to the dependencies.
