### PR TITLE
clean up debian/rules

### DIFF
--- a/Debian/debian/rules
+++ b/Debian/debian/rules
@@ -9,9 +9,6 @@ override_dh_auto_clean:
 	dh_auto_clean
 	rm -rf out
 
-override_dh_auto_install:
-	dh_auto_install --destdir=$(CURDIR)/debian/tmp
-
 override_dh_install:
 	dh_install -XLICENSE -XAUTHORS -X.md
 	install -m755 debian/tmp/usr/bin/notepadqq \
@@ -20,5 +17,3 @@ override_dh_install:
 override_dh_installdocs:
 	dh_installdocs --link-doc=notepadqq-common
 
-override_dh_builddeb:
-	dh_builddeb -- -Zxz -z9


### PR DESCRIPTION
Overriding dh_auto_install isn't necessary if we build more than one binary package. And explicitly setting the compression to xz is not needed too since nowadays xz is set by default (this would be necessary for Ubuntu 12.04, but because of missing build dependencies this package doesn't build on that distribution anyway).