### PR TITLE
Updating repo links for packages.

### DIFF
--- a/Arch_Linux/README.md
+++ b/Arch_Linux/README.md
@@ -1,10 +1,7 @@
 Links to AUR4 repos for the packages since they have moved to Git repo to host their PKGBUILDS.
 
-* [Arch_Linux/notepadqq-bin](https://aur4.archlinux.org/packages/notepadqq-bin/)
-  * url = https://aur@aur4.archlinux.org/notepadqq-bin.git
+* [Arch_Linux/notepadqq-bin and notepadqq-common](https://aur.archlinux.org/pkgbase/notepadqq/)
+  * url = https://aur.archlinux.org/notepadqq.git
 
-* [Arch_Linux/notepadqq-git](https://aur4.archlinux.org/packages/notepadqq-git/)
-  * url = https://aur@aur4.archlinux.org/notepadqq-git.git
-	
-* [Arch_Linux/notepadqq-common](https://aur4.archlinux.org/packages/notepadqq-common/)
-  * url = https://aur@aur4.archlinux.org/notepadqq-common.git
+* [Arch_Linux/notepadqq-git](https://aur.archlinux.org/notepadqq-git.git)
+  * url = https://aur.archlinux.org/notepadqq-git.git


### PR DESCRIPTION
Notepadqq-common has been merged into notepadqq-bin under the same package base.