### PR TITLE
Patch for fedora

### DIFF
--- a/Fedora/readme.md
+++ b/Fedora/readme.md
@@ -10,11 +10,11 @@ Steps:
 
 $ rpmdev-setuptree
 
-3- Copy sources to folders
+3- Copy sources to folders (You can see it in Source0 and Source1 in the .spec file)
 
-$ wget https://github.com/notepadqq/notepadqq/archive/v1.0.1.tar.gz -O ~/rpmbuild/SOURCES/notepadqq-1.0.1.tar.gz
+$ wget https://github.com/notepadqq/notepadqq/archive/v1.0.1.tar.gz -O ~/rpmbuild/SOURCES/v1.0.1.tar.gz
 
-$ wget https://github.com/notepadqq/CodeMirror/archive/5.18.2-nqq.tar.gz -O ~/rpmbuild/SOURCES/CodeMirror-5.18.2-nqq.tar.gz
+$ wget https://github.com/notepadqq/CodeMirror/archive/5.18.2-nqq.tar.gz -O ~/rpmbuild/SOURCES/5.18.2-nqq.tar.gz
 
 $ wget https://raw.githubusercontent.com/notepadqq/notepadqq-packaging/master/Fedora/notepadqq.spec -O ~/rpmbuild/SOURCES/notepadqq.spec
 


### PR DESCRIPTION
Fedora patches to .spec, now rpmlint has 0 errors

I will send you a patch of launcher script in notepadqq for add fedora support (Like the debian one)