### PR TITLE
Update ArchLinux places

### DIFF
--- a/Arch_Linux/README.md
+++ b/Arch_Linux/README.md
@@ -1,7 +1,7 @@
-Links to AUR4 repos for the packages since they have moved to Git repo to host their PKGBUILDS.
+Links to ArchLinux PKGBUILDS and URLs of notepadqq
 
-* [Arch_Linux/notepadqq-bin and notepadqq-common](https://aur.archlinux.org/pkgbase/notepadqq/)
-  * url = https://aur.archlinux.org/notepadqq.git
+* [Arch_Linux/notepadqq (Old notepadqq-bin and notepadqq-common)](https://www.archlinux.org/packages/community/x86_64/notepadqq/)
+  * url = https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/notepadqq
 
-* [Arch_Linux/notepadqq-git](https://aur.archlinux.org/notepadqq-git.git)
-  * url = https://aur.archlinux.org/notepadqq-git.git
+* [Arch_Linux/notepadqq-git](https://aur.archlinux.org/packages/notepadqq-git/)
+  * url = https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=notepadqq-git


### PR DESCRIPTION
Notepadqq is in community
URL to pkgbuilds direcly and names link to Arch repo url